### PR TITLE
inheritance of settings

### DIFF
--- a/django_cryptography/conf.py
+++ b/django_cryptography/conf.py
@@ -7,10 +7,25 @@ from django.utils.encoding import force_bytes
 
 
 class CryptographyConf(AppConf):
-    BACKEND = default_backend()
-    DIGEST = hashes.SHA256()
-    KEY = None
-    SALT = 'django-cryptography'
+    if not hasattr(settings, 'CRYPTOGRAPHY_BACKEND'):
+        BACKEND = default_backend()
+    else:
+        BACKEND = settings.CRYPTOGRAPHY_BACKEND
+
+    if not hasattr(settings, 'CRYPTOGRAPHY_DIGEST'):
+        DIGEST = hashes.SHA256()
+    else:
+        DIGEST = settings.CRYPTOGRAPHY_DIGEST
+
+    if not hasattr(settings, 'CRYPTOGRAPHY_KEY'):
+        KEY = None
+    else:
+        KEY = settings.CRYPTOGRAPHY_KEY
+
+    if not hasattr(settings, 'CRYPTOGRAPHY_SALT'):
+        SALT = 'django-cryptography'
+    else:
+        SALT = settings.CRYPTOGRAPHY_SALT
 
     class Meta:
         prefix = 'cryptography'

--- a/django_cryptography/conf.py
+++ b/django_cryptography/conf.py
@@ -27,6 +27,11 @@ class CryptographyConf(AppConf):
     else:
         SALT = settings.CRYPTOGRAPHY_SALT
 
+    if not hasattr(settings, 'CRYPTOGRAPHY_SIGNINGKEY'):
+        SIGNINGKEY = None
+    else:
+        SIGNINGKEY = settings.CRYPTOGRAPHY_SIGNINGKEY
+
     class Meta:
         prefix = 'cryptography'
         proxy = True
@@ -49,4 +54,14 @@ class CryptographyConf(AppConf):
         self.configured_data['KEY'] = kdf.derive(
             force_bytes(self.configured_data['KEY'] or settings.SECRET_KEY)
         )
+        # In order to keep parity with django signing functions, SIGNINGKEY defaults to SECRET_KEY
+        if self.configured_data['SIGNINGKEY'] == None:
+            self.configured_data['SIGNINGKEY'] = force_bytes(settings.SECRET_KEY)
+        else:
+            if self.configured_data['SIGNINGKEY'] == 'SECRET_KEY':
+                self.configured_data['SIGNINGKEY'] = force_bytes(settings.SECRET_KEY)
+            elif self.configured_data['SIGNINGKEY'] == 'CRYPTOGRAPHY_KEY':
+                self.configured_data['SIGNINGKEY'] = self.configured_data['KEY']
+            else:
+                SIGNINGKEY = force_bytes(settings.CRYPTOGRAPHY_SIGNINGKEY)
         return self.configured_data

--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -38,7 +38,7 @@ def base64_hmac(salt, value, key):
 def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, compress=False):
     """
     Returns URL-safe, sha1 signed base64 compressed JSON string. If key is
-    None, settings.SECRET_KEY is used instead.
+    None, settings.CRYPTOGRAPHY_KEY is used instead.
 
     If compress is True (not the default) checks if compressing using zlib can
     save some space. Prepends a '.' to signify compression. This is included

--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -38,7 +38,7 @@ def base64_hmac(salt, value, key):
 def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, compress=False):
     """
     Returns URL-safe, sha1 signed base64 compressed JSON string. If key is
-    None, settings.CRYPTOGRAPHY_KEY is used instead.
+    None, settings.CRYPTOGRAPHY_SIGNINGKEY is used instead.
 
     If compress is True (not the default) checks if compressing using zlib can
     save some space. Prepends a '.' to signify compression. This is included
@@ -91,7 +91,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
 class Signer(object):
     def __init__(self, key=None, sep=':', salt=None):
         # Use of native strings in all versions of Python
-        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_SIGNINGKEY)
         self.sep = force_str(sep)
         if _SEP_UNSAFE.match(self.sep):
             raise ValueError(
@@ -152,7 +152,7 @@ class BytesSigner(Signer):
     def __init__(self, key=None, salt=None):
         digest = settings.CRYPTOGRAPHY_DIGEST
         self._digest_size = digest.digest_size
-        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_SIGNINGKEY)
         self.salt = force_str(salt or '%s.%s' % (
             self.__class__.__module__, self.__class__.__name__))
 
@@ -181,7 +181,7 @@ class FernetSigner(Signer):
         :rtype: None
         """
         self.digest = settings.CRYPTOGRAPHY_DIGEST
-        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_SIGNINGKEY)
 
     def signature(self, value):
         """

--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -10,7 +10,8 @@ import zlib
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.hmac import HMAC
-from django.conf import settings
+from ..conf import CryptographyConf
+settings = CryptographyConf()
 from django.core.signing import (
     BadSignature, SignatureExpired, b64_encode, b64_decode,
     get_cookie_signer, JSONSerializer
@@ -90,7 +91,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
 class Signer(object):
     def __init__(self, key=None, sep=':', salt=None):
         # Use of native strings in all versions of Python
-        self.key = key or settings.SECRET_KEY
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
         self.sep = force_str(sep)
         if _SEP_UNSAFE.match(self.sep):
             raise ValueError(
@@ -151,7 +152,7 @@ class BytesSigner(Signer):
     def __init__(self, key=None, salt=None):
         digest = settings.CRYPTOGRAPHY_DIGEST
         self._digest_size = digest.digest_size
-        self.key = key or settings.SECRET_KEY
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
         self.salt = force_str(salt or '%s.%s' % (
             self.__class__.__module__, self.__class__.__name__))
 
@@ -179,8 +180,8 @@ class FernetSigner(Signer):
         :type key: any
         :rtype: None
         """
-        self.digest = hashes.SHA256()
-        self.key = force_bytes(key or settings.SECRET_KEY)
+        self.digest = settings.CRYPTOGRAPHY_DIGEST
+        self.key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
 
     def signature(self, value):
         """

--- a/django_cryptography/utils/crypto.py
+++ b/django_cryptography/utils/crypto.py
@@ -30,11 +30,9 @@ def salted_hmac(salt, value, secret=None):
     :type secret: any
     :rtype: HMAC
     """
-    if secret is None:
-        secret = settings.CRYPTOGRAPHY_KEY
 
     salt = force_bytes(salt)
-    secret = force_bytes(secret)
+    secret = force_bytes(secret or settings.CRYPTOGRAPHY_KEY)
 
     # We need to generate a derived key from our base key.  We can do this by
     # passing the salt and our base key through a pseudo-random function and

--- a/django_cryptography/utils/crypto.py
+++ b/django_cryptography/utils/crypto.py
@@ -21,7 +21,7 @@ class InvalidToken(Exception):
 def salted_hmac(salt, value, secret=None):
     """
     Returns the HMAC-HASH of 'value', using a key generated from salt and a
-    secret (which defaults to settings.CRYPTOGRAPHY_KEY).
+    secret (which defaults to settings.CRYPTOGRAPHY_SIGNINGKEY).
 
     A different salt should be passed in for every application of HMAC.
 
@@ -32,7 +32,7 @@ def salted_hmac(salt, value, secret=None):
     """
 
     salt = force_bytes(salt)
-    secret = force_bytes(secret or settings.CRYPTOGRAPHY_KEY)
+    secret = force_bytes(secret or settings.CRYPTOGRAPHY_SIGNINGKEY)
 
     # We need to generate a derived key from our base key.  We can do this by
     # passing the salt and our base key through a pseudo-random function and
@@ -101,7 +101,7 @@ class FernetBytes(object):
         self._encryption_key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
         if signer is None:
             from ..core.signing import FernetSigner
-            signer = FernetSigner(self._encryption_key)
+            signer = FernetSigner()
         self._signer = signer
 
     def encrypt(self, data):

--- a/django_cryptography/utils/crypto.py
+++ b/django_cryptography/utils/crypto.py
@@ -99,11 +99,11 @@ class FernetBytes(object):
     """
 
     def __init__(self, key=None, signer=None):
+        self._backend = settings.CRYPTOGRAPHY_BACKEND
+        self._encryption_key = force_bytes(key or settings.CRYPTOGRAPHY_KEY)
         if signer is None:
             from ..core.signing import FernetSigner
-            signer = FernetSigner()
-        self._backend = settings.CRYPTOGRAPHY_BACKEND
-        self._encryption_key = key or settings.CRYPTOGRAPHY_KEY
+            signer = FernetSigner(self._encryption_key)
         self._signer = signer
 
     def encrypt(self, data):

--- a/django_cryptography/utils/crypto.py
+++ b/django_cryptography/utils/crypto.py
@@ -18,14 +18,14 @@ class InvalidToken(Exception):
     pass
 
 
-def salted_hmac(key_salt, value, secret=None):
+def salted_hmac(salt, value, secret=None):
     """
-    Returns the HMAC-HASH of 'value', using a key generated from key_salt and a
-    secret (which defaults to settings.SECRET_KEY).
+    Returns the HMAC-HASH of 'value', using a key generated from salt and a
+    secret (which defaults to settings.CRYPTOGRAPHY_KEY).
 
-    A different key_salt should be passed in for every application of HMAC.
+    A different salt should be passed in for every application of HMAC.
 
-    :type key_salt: any
+    :type salt: any
     :type value: any
     :type secret: any
     :rtype: HMAC
@@ -33,15 +33,15 @@ def salted_hmac(key_salt, value, secret=None):
     if secret is None:
         secret = settings.CRYPTOGRAPHY_KEY
 
-    key_salt = force_bytes(key_salt)
+    salt = force_bytes(salt)
     secret = force_bytes(secret)
 
     # We need to generate a derived key from our base key.  We can do this by
-    # passing the key_salt and our base key through a pseudo-random function and
+    # passing the salt and our base key through a pseudo-random function and
     # SHA1 works nicely.
     digest = hashes.Hash(settings.CRYPTOGRAPHY_DIGEST,
                          backend=settings.CRYPTOGRAPHY_BACKEND)
-    digest.update(key_salt + secret)
+    digest.update(salt + secret)
     key = digest.finalize()
 
     # If len(key_salt + secret) > sha_constructor().block_size, the above

--- a/django_cryptography/utils/crypto.py
+++ b/django_cryptography/utils/crypto.py
@@ -31,7 +31,7 @@ def salted_hmac(key_salt, value, secret=None):
     :rtype: HMAC
     """
     if secret is None:
-        secret = settings.SECRET_KEY
+        secret = settings.CRYPTOGRAPHY_KEY
 
     key_salt = force_bytes(key_salt)
     secret = force_bytes(secret)

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/tests/utils/crypto/tests.py
+++ b/tests/utils/crypto/tests.py
@@ -208,6 +208,7 @@ class FernetBytesTestCase(unittest.TestCase):
             '3af94f1c73e82b00d41d2db759b54af2e31c55dc97a51c3c3ae8b83eb46dd2b8')
 
     @override_settings(SECRET_KEY=b'test_key')
+    @override_settings(CRYPTOGRAPHY_SIGNINGKEY=b'test_key')
     @override_settings(CRYPTOGRAPHY_DIGEST=hashes.SHA256())
     @override_settings(CRYPTOGRAPHY_SALT=b'salted_hmac')
     @override_settings(CRYPTOGRAPHY_BACKEND=default_backend())
@@ -220,12 +221,13 @@ class FernetBytesTestCase(unittest.TestCase):
                 'ddaec2d74fb4ff565280abdc39baf116e80f116496cde9515bd7d938e5c74'
                 'd60bc186286e701ba4fb4004')
         with freeze_time(123456789):
-            fernet = FernetBytes(settings.CRYPTOGRAPHY_KEY, FernetSigner(settings.SECRET_KEY))
+            fernet = FernetBytes()
             self.assertEqual(fernet._encrypt_from_parts(value, iv),
                              binascii.unhexlify(data))
             self.assertEqual(fernet.decrypt(binascii.unhexlify(data)), value)
 
     @override_settings(SECRET_KEY=b'test_key')
+    @override_settings(CRYPTOGRAPHY_SIGNINGKEY=b'test_key')
     @override_settings(CRYPTOGRAPHY_DIGEST=hashes.SHA256())
     @override_settings(CRYPTOGRAPHY_SALT=b'salted_hmac')
     @override_settings(CRYPTOGRAPHY_BACKEND=default_backend())
@@ -236,11 +238,12 @@ class FernetBytesTestCase(unittest.TestCase):
                 'ddaec2d74fb4ff565d549d94cc75de940d1d25507f30763f05c412390d15d'
                 'a26bccee69f1b4543e75')
         with freeze_time(123456789):
-            fernet = FernetBytes(settings.CRYPTOGRAPHY_KEY, FernetSigner(settings.SECRET_KEY))
+            fernet = FernetBytes()
             with self.assertRaises(InvalidToken):
                 fernet.decrypt(binascii.unhexlify(data))
 
     @override_settings(SECRET_KEY=b'test_key')
+    @override_settings(CRYPTOGRAPHY_SIGNINGKEY=b'test_key')
     @override_settings(CRYPTOGRAPHY_DIGEST=hashes.SHA256())
     @override_settings(CRYPTOGRAPHY_SALT=b'salted_hmac')
     @override_settings(CRYPTOGRAPHY_BACKEND=default_backend())
@@ -251,7 +254,7 @@ class FernetBytesTestCase(unittest.TestCase):
                 '8f001b78b5a77b334b40fbbff559444b3325233e71c24e53f6028116b0377'
                 'b910ebe5498396de36dee59b')
         with freeze_time(123456789):
-            fernet = FernetBytes(settings.CRYPTOGRAPHY_KEY, FernetSigner(settings.SECRET_KEY))
+            fernet = FernetBytes()
             with self.assertRaises(InvalidToken):
                 fernet.decrypt(binascii.unhexlify(data))
 

--- a/tests/utils/crypto/tests.py
+++ b/tests/utils/crypto/tests.py
@@ -24,8 +24,8 @@ class TestUtilsCryptoMisc(unittest.TestCase):
     @override_settings(CRYPTOGRAPHY_DIGEST=hashes.SHA1())
     def test_django_hmac_parity(self):
         django_hmac = django_salted_hmac(self.salt, self.value)
-        cryptography_hmac = salted_hmac(self.salt, self.value)
-
+        cryptography_hmac = salted_hmac(self.salt, self.value, settings.SECRET_KEY)
+        
         self.assertEqual(django_hmac.digest(), cryptography_hmac.finalize())
 
     def test_constant_time_compare(self):


### PR DESCRIPTION
Main changes are related to the inheritance of the options defined in settings.py though the rest of the code. Other minor changes to clarify name variables (case of key_salt in salted_hmac).

Most of the tests pass, but 3 (1 failure: test_encrypt_decrypt; and 2 errors: test_decryptor_invalid_token and test_unpadder_invalid_token, that both raise BadSignature errors instead of InvalidToken error).

Thanks.
