### PR TITLE
New setting ALLOW_UNENCRYPTED 

### DIFF
--- a/django_cryptography/conf.py
+++ b/django_cryptography/conf.py
@@ -11,6 +11,7 @@ class CryptographyConf(AppConf):
     DIGEST = hashes.SHA256()
     KEY = None
     SALT = 'django-cryptography'
+    ALLOW_UNENCRYPTED = False
 
     class Meta:
         prefix = 'cryptography'
@@ -35,3 +36,5 @@ class CryptographyConf(AppConf):
             force_bytes(self.configured_data['KEY'] or settings.SECRET_KEY)
         )
         return self.configured_data
+
+

--- a/django_cryptography/fields.py
+++ b/django_cryptography/fields.py
@@ -6,7 +6,7 @@ from django.utils import six
 from django.utils.encoding import force_bytes
 from django.utils.translation import ugettext_lazy as _
 
-from django_cryptography.core.signing import SignatureExpired
+from django_cryptography.core.signing import SignatureExpired, BadSignature
 from django_cryptography.utils.crypto import FernetBytes
 
 try:
@@ -18,6 +18,10 @@ FIELD_CACHE = {}
 
 Expired = object()
 """Represents an expired encryption value."""
+
+from .conf import CryptographyConf
+
+settings = CryptographyConf()
 
 
 class PickledField(models.Field):
@@ -122,6 +126,10 @@ class EncryptedMixin(object):
             return pickle.loads(
                 self._fernet.decrypt(value, self.ttl)
             )
+        except BadSignature:
+            if settings.ALLOW_UNENCRYPTED:
+                return value
+            raise
         except SignatureExpired:
             return Expired
 


### PR DESCRIPTION
We found it awkward to introduce django-cryptography to existing data, so we added a new setting ALLOW_UNENCRYPTED (default False), which allows unencrypted data to be READ (read only), instead of throwing a BadSignature error. When the data gets written it's still encrypted.