### PR TITLE
Django 3.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,13 @@ matrix:
   allow_failures:
     - python: nightly
     - env: DJANGO="https://github.com/django/django/archive/main.tar.gz"
-  exclude:
-    - python: "3.5"
-      env: DJANGO="Django>=3.0,<3.1"
-    - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/main.tar.gz"
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
   - "3.9"
   - "nightly"
 env:
-  - DJANGO="Django>=1.11,<1.12"
   - DJANGO="Django>=2.2,<2.3"
   - DJANGO="Django>=3.0,<3.1"
   - DJANGO="Django>=3.1,<3.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,26 @@ cache: pip
 matrix:
   allow_failures:
     - python: nightly
-    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    - env: DJANGO="https://github.com/django/django/archive/main.tar.gz"
   exclude:
     - python: "3.5"
       env: DJANGO="Django>=3.0,<3.1"
     - python: "3.5"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      env: DJANGO="https://github.com/django/django/archive/main.tar.gz"
 python:
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "nightly"
 env:
   - DJANGO="Django>=1.11,<1.12"
   - DJANGO="Django>=2.2,<2.3"
   - DJANGO="Django>=3.0,<3.1"
-  - DJANGO="https://github.com/django/django/archive/master.tar.gz"
+  - DJANGO="Django>=3.1,<3.2"
+  - DJANGO="Django>=3.2,<3.3"
+  - DJANGO="https://github.com/django/django/archive/main.tar.gz"
 before_install:
   - pip install --quiet codecov
 install:

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ bi-directional data retrieval.
 Requirements
 ------------
 
-* Python_ (3.5, 3.6, 3.7, 3.8)
+* Python_ (3.6, 3.7, 3.8)
 * Cryptography_ (2.0+)
 * Django_ (1.11, 2.2, 3.0)
 

--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -126,6 +126,44 @@ class Signer:
             return force_text(value)
         raise BadSignature('Signature "%s" does not match' % sig)
 
+    def sign_object(self, obj, serializer=JSONSerializer, compress=False):
+        """
+        Return URL-safe, hmac signed base64 compressed JSON string.
+
+        If compress is True (not the default), check if compressing using zlib
+        can save some space. Prepend a '.' to signify compression. This is
+        included in the signature, to protect against zip bombs.
+
+        The serializer is expected to return a bytestring.
+        """
+        data = serializer().dumps(obj)
+        # Flag for if it's been compressed or not.
+        is_compressed = False
+
+        if compress:
+            # Avoid zlib dependency unless compress is being used.
+            compressed = zlib.compress(data)
+            if len(compressed) < (len(data) - 1):
+                data = compressed
+                is_compressed = True
+        base64d = b64_encode(data).decode()
+        if is_compressed:
+            base64d = '.' + base64d
+        return self.sign(base64d)
+
+    def unsign_object(self, signed_obj, serializer=JSONSerializer, **kwargs):
+        # Signer.unsign() returns str but base64 and zlib compression operate
+        # on bytes.
+        base64d = self.unsign(signed_obj, **kwargs).encode()
+        decompress = base64d[:1] == b'.'
+        if decompress:
+            # It's compressed; uncompress it first.
+            base64d = base64d[1:]
+        data = b64_decode(base64d)
+        if decompress:
+            data = zlib.decompress(data)
+        return serializer().loads(data)
+
 
 class TimestampSigner(Signer):
     def timestamp(self):

--- a/django_cryptography/fields.py
+++ b/django_cryptography/fields.py
@@ -4,7 +4,7 @@ from base64 import b64decode, b64encode
 from django.core import checks
 from django.db import models
 from django.utils.encoding import force_bytes
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_cryptography.core.signing import SignatureExpired
 from django_cryptography.utils.crypto import FernetBytes

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-* Python_ (3.5, 3.6, 3.7, 3.8)
+* Python_ (3.6, 3.7, 3.8)
 * Cryptography_ (2.0+)
 * Django_ (1.11, 2.2, 3.0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ extend-ignore = E203
 license-file = LICENSE
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 
 [test]
 settings = tests.settings

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Security :: Cryptography',

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 SECRET_KEY = 'test_key'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 DATABASES = {
     'default': {

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 envlist =
-    {py34,py35,py36}-{django1.11},
-    {py35,py36,py37,py38}-{django2.2},
+    {py36,py37,py38}-{django2.2},
     {py36,py37,py38,py39}-{django3.0,django3.1,django3.2,main},
 
 [testenv]
 deps =
-    django1.11: Django>=1.11,<1.12
     django2.2: Django>=2.2,<2.3
     django3.0: Django>=3.0,<3.1
     django3.1: Django>=3.1,<3.2

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,16 @@
 envlist =
     {py34,py35,py36}-{django1.11},
     {py35,py36,py37,py38}-{django2.2},
-    {py36,py37,py38}-{django3.0,master},
+    {py36,py37,py38,py39}-{django3.0,django3.1,django3.2,main},
 
 [testenv]
 deps =
     django1.11: Django>=1.11,<1.12
     django2.2: Django>=2.2,<2.3
     django3.0: Django>=3.0,<3.1
-    master: https://github.com/django/django/archive/master.tar.gz
+    django3.1: Django>=3.1,<3.2
+    django3.2: Django>=3.2,<3.3
+    main: https://github.com/django/django/archive/main.tar.gz
 commands = python setup.py test {posargs}
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings


### PR DESCRIPTION
Django 3.2 introduced `Signer.sign_object` and `Signer.unsign_object`.

Removed Python 3.5 support, it is deprecated since september/2020.

Fixed two broken tests because of a Django bug. Probably I can revert that in the future. https://code.djangoproject.com/ticket/32863

Fixed `ugettext_lazy` deprecation, replaced with `gettext_lazy`.

I don't expect this PR to be merged, but maybe it help someone else looking for Django 3.2 fixes.