### PR TITLE
#62 Changes required to enable the use of Django 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,14 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
+  - "3.10"
   - "nightly"
 env:
   - DJANGO="Django>=1.11,<1.12"
   - DJANGO="Django>=2.2,<2.3"
-  - DJANGO="Django>=3.0,<3.1"
+  - DJANGO="Django>=3.0,<4.0"
+  - DJANGO="Django>=4.0,<5.0"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 before_install:
   - pip install --quiet codecov

--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -15,7 +15,7 @@ from django.core.signing import (BadSignature, JSONSerializer,
                                  SignatureExpired, b64_decode, b64_encode,
                                  get_cookie_signer)
 from django.utils import baseconv
-from django.utils.encoding import force_bytes, force_str, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from ..utils.crypto import constant_time_compare, salted_hmac
 
@@ -123,7 +123,7 @@ class Signer:
             raise BadSignature('No "%s" found in value' % self.sep)
         value, sig = signed_value.rsplit(self.sep, 1)
         if constant_time_compare(sig, self.signature(value)):
-            return force_text(value)
+            return force_str(value)
         raise BadSignature('Signature "%s" does not match' % sig)
 
 

--- a/django_cryptography/fields.py
+++ b/django_cryptography/fields.py
@@ -4,7 +4,7 @@ from base64 import b64decode, b64encode
 from django.core import checks
 from django.db import models
 from django.utils.encoding import force_bytes
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_cryptography.core.signing import SignatureExpired
 from django_cryptography.utils.crypto import FernetBytes

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,14 @@ envlist =
     {py34,py35,py36}-{django1.11},
     {py35,py36,py37,py38}-{django2.2},
     {py36,py37,py38}-{django3.0,master},
+    {py36,py37,py38,py39,py310}-{django4.0,master},
 
 [testenv]
 deps =
     django1.11: Django>=1.11,<1.12
     django2.2: Django>=2.2,<2.3
-    django3.0: Django>=3.0,<3.1
+    django3.0: Django>=3.0,<4.0
+    django4.0: Django>=4.0,<5.0
     master: https://github.com/django/django/archive/master.tar.gz
 commands = python setup.py test {posargs}
 setenv =


### PR DESCRIPTION
This will break Python 2 usage as force_text() is no longer available.