### PR TITLE
Fixed: ImportError: cannot import name force_text from django.utils.e…

### DIFF
--- a/django_cryptography/core/signing.py
+++ b/django_cryptography/core/signing.py
@@ -15,7 +15,7 @@ from django.core.signing import (BadSignature, JSONSerializer,
                                  SignatureExpired, b64_decode, b64_encode,
                                  get_cookie_signer)
 from django.utils import baseconv
-from django.utils.encoding import force_bytes, force_str, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from ..utils.crypto import constant_time_compare, salted_hmac
 

--- a/django_cryptography/fields.py
+++ b/django_cryptography/fields.py
@@ -4,7 +4,7 @@ from base64 import b64decode, b64encode
 from django.core import checks
 from django.db import models
 from django.utils.encoding import force_bytes
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_cryptography.core.signing import SignatureExpired
 from django_cryptography.utils.crypto import FernetBytes


### PR DESCRIPTION
Fixed: ImportError: cannot import name force_text from django.utils.encoding in django4.0 & in fields.py ugettext_lazy: import error --> change to gettext_lazy'