### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Cryptography_ as the backend provider.
 Do not forget to read the documentation_.
 
 .. START HIDDEN
-.. image:: https://img.shields.io/github/workflow/status/georgemarshall/django-cryptography/CI/master
+.. image:: https://img.shields.io/github/actions/workflow/status/georgemarshall/django-cryptography/main.yml?branch=master
    :target: https://github.com/georgemarshall/django-cryptography/actions/workflows/main.yml
    :alt: GitHub Workflow Status (branch)
 .. image:: https://img.shields.io/codecov/c/github/georgemarshall/django-cryptography/master


### PR DESCRIPTION
fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main