### PR TITLE
Update setup.cfg to auto-discover sub-packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ project_urls =
     Documentation = https://django-cryptography.readthedocs.io
 
 [options]
-packages = django_cryptography
+packages = find:
 python_requires = >=3.7
 include_package_data = True
 install_requires =


### PR DESCRIPTION
Modify the packages option in setup.cfg to use the find: directive, which enables setuptools to automatically discover all sub-packages. This change fixes the installation issue where sub-packages were not being included when installing directly from git repo. ( like this `pip install git+https://github.com/georgemarshall/django-cryptography` )