### PR TITLE
Added Django 5.0, 5.1 and Python 3.12 to test matrix. Fixes #74.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 * Python_ (3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
 * Cryptography_ (2.0+)
-* Django_ (3.2, 4.1, 4.2, 5.0)
+* Django_ (3.2, 4.1, 4.2, 5.0, 5.1)
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ bi-directional data retrieval.
 Requirements
 ------------
 
-* Python_ (3.7, 3.8, 3.9, 3.10, 3.11)
+* Python_ (3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
 * Cryptography_ (2.0+)
-* Django_ (3.2, 4.1, 4.2)
+* Django_ (3.2, 4.1, 4.2, 5.0)
 
 Installation
 ------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,9 +4,9 @@ Installation
 Requirements
 ------------
 
-* Python_ (3.7, 3.8, 3.9, 3.10, 3.11)
+* Python_ (3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
 * Cryptography_ (2.0+)
-* Django_ (3.2, 4.1, 4.2)
+* Django_ (3.2, 4.1, 4.2, 5.0)
 
 .. code-block:: console
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Requirements
 
 * Python_ (3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
 * Cryptography_ (2.0+)
-* Django_ (3.2, 4.1, 4.2, 5.0)
+* Django_ (3.2, 4.1, 4.2, 5.0, 5.1)
 
 .. code-block:: console
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,15 @@ target-version = "py37"
 [tool.tox]
 # language=ini
 legacy_tox_ini = """
+
 [tox]
 min_version = 4.0
 envlist =
     {py37,py38,py39,py310}-django32,
     {py38,py39,py310}-django41,
     {py38,py39,py310,py311}-django42,
-    {py310,py311}-djangomain,
+    {py310,py311,py312}-django50,
+    {py310,py311,py312}-djangomain,
 isolated_build = True
 
 [testenv]
@@ -72,6 +74,7 @@ deps =
     django32: Django>=3.2,<3.3
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 commands =
     {envpython} -m coverage run --context='{envname}' runtests.py {posargs}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ envlist =
     {py38,py39,py310}-django41,
     {py38,py39,py310,py311}-django42,
     {py310,py311,py312}-django50,
+    {py310,py311,py312}-django51,
     {py310,py311,py312}-djangomain,
 isolated_build = True
 
@@ -75,6 +76,7 @@ deps =
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
 commands =
     {envpython} -m coverage run --context='{envname}' runtests.py {posargs}


### PR DESCRIPTION
The changes to support Django 5.0 are already on master, so this PR adds it to test matrix to resolve #74

Also, Django 5.0 [dropped support](https://docs.djangoproject.com/en/5.0/releases/5.0/#python-compatibility) for Python < 3.10 and added 3.12